### PR TITLE
Changed to Relative URL

### DIFF
--- a/public/docs/_examples/webpack/ts/config/webpack.dev.js
+++ b/public/docs/_examples/webpack/ts/config/webpack.dev.js
@@ -9,7 +9,7 @@ module.exports = webpackMerge(commonConfig, {
   
   output: {
     path: helpers.root('dist'),
-    publicPath: 'http://localhost:8080/',
+    publicPath: './',
     filename: '[name].js',
     chunkFilename: '[id].chunk.js'
   },


### PR DESCRIPTION
This will fix the webpack tutorial for people who develop on remote machines.